### PR TITLE
add to README section about usage with spotbugs-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ These instructions will get you a copy of the project up and running on your loc
 To build the performance-tests-checker plugin you just need Java and Maven.
 
 ```
-Java 7 or higher
-Maven 
+Java 8 or higher
 ```
 
 ### Building
@@ -24,13 +23,13 @@ You can use Maven to generate the jar file necessary for deployment.
 First compile the source of the project  
 
 ```
-mvn compile
+./mvnw compile
 ```
 
 And simply pack the compiled code into the jar format. This jar will then be used to integrate our rules to SpotBugs program. 
 
 ```
-mvn package
+./mvnw package
 ```
 
 
@@ -58,6 +57,53 @@ This makes it easy for users to add their own detectors alongside the ones that 
 4. Execute the `$SPOTBUGS_HOME/lib/spotbugs.jar` with the `-textui` command line to get the list of all possible line commands of SpotBugs.
    
   1. To make sure that you have deployed a valid plugin jar, you can run the command `java -jar $SPOTBUGS_HOME/lib/spotbugs.jar -textui -showPlugins`. The performance-checker plugin should be listed in the Available plugins.  
+
+### Usage with spotbugs-maven-plugin ###
+To fail maven build of your JMH-project if there are some bugs spotted, add to the root of the probject file `spotbugs-exclude.xml` with content:
+```
+<FindBugsFilter>
+    <Match>
+        <Class name="~.*jmhTest"/>
+    </Match>
+    <Match>
+        <Class name="~.*jmhType.*"/>
+    </Match>
+    <Match>
+        <Bug pattern="JMH_BENCHMARK_METHOD_FOUND"/>
+    </Match>
+</FindBugsFilter>
+```
+It is needed to exclude generated jmh classes from analysis and to exclude noop-pattern that will always fail your build (will be removed in #5)
+
+Than add to you `pom.xml` to the build plugins
+```
+<plugin>
+    <groupId>com.github.spotbugs</groupId>
+    <artifactId>spotbugs-maven-plugin</artifactId>
+    <version>3.1.12</version>
+    <executions>
+        <execution>
+            <id>spotbugs</id>
+            <goals>
+                <goal>check</goal>
+            </goals>
+        </execution>
+    </executions>
+    <configuration>
+        <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+        <fork>false</fork>
+        <plugins>
+            <plugin>
+                <groupId>de.heidelberg.pvs.diego</groupId>
+                <artifactId>spotJMHbugs</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </plugin>
+        </plugins>
+    </configuration>
+</plugin>
+```
+
+After that running `verify` stage will check your jmh-project and fail the build if there are any bugs (from the core of spotbugs project and specfic to JMH spotted by this project)
 
 
 ## Bad JMH Practices ##


### PR DESCRIPTION
I think there are enough nuances (the main one with excluding jmh-generated classes) to have such section in README